### PR TITLE
Use arxiv icon

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -13,7 +13,8 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon/favicon-16x16.png">
 <link rel="manifest" href="/assets/favicon/site.webmanifest">
 <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="stylesheet"href="https://fonts.googleapis.com/css?family=Montserrat">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
 <script type="text/javascript" async

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -90,7 +90,7 @@ layout: default
                             {% if page.arxiv %}
                             <li class="publication__social__link">
                                 <a href="{{ page.arxiv }}" target="_blank" rel="noopener noreferrer">
-                                    <i class="far fa-file-pdf"></i>
+                                    <i class="ai ai-arxiv"></i>
                                 </a>
                             </li>
                             {% endif %}


### PR DESCRIPTION
This pull request updates the icon used for arxiv links in the project. The previous icon was a file PDF icon, and it has been replaced with the arxiv icon from the academicons library.