### PR TITLE
Remove link underscore from asterisks

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -19,22 +19,20 @@ layout: default
                         <li class="publication__author_list_item">
 
                             <span class="publication__author_name">
-                                {% if author.url %}
-                                    <a href="{{ author.url }}" target="_blank" rel="noopener noreferrer" itemprop="author" itemscope
+                                <span itemprop="name">
+                                {%- if author.url or author.scholar -%}
+                                    <a href="{% if author.url %}{{ author.url }}{% elsif author.scholar %}https://scholar.google.com/citations?user={{ author.scholar }}{% endif %}"
+                                    target="_blank" rel="noopener noreferrer" itemprop="author" itemscope
                                     itemtype="https://schema.org/Person">
-                                {% elsif author.scholar %}
-                                    <a href="https://scholar.google.com/citations?user={{ author.scholar }}" target="_blank" rel="noopener noreferrer" itemprop="author" itemscope
-                                        itemtype="https://schema.org/Person">
-                                {% endif %}
-                                {% if page.n_equal_contrib > 1 and forloop.index0 < page.n_equal_contrib %}
-                                    <span itemprop="name">{{ author.firstname[3] }}<sup>&ast;</sup></span>
-                                {% else %}
-                                    <span itemprop="name">{{ author.firstname[3] }}</span>
-                                {% endif %}
-
-                                {% if author.url or author.scholar %}
+                                {%- endif -%}
+                                {{ author.firstname[3] }}
+                                {%- if author.url or author.scholar -%}
                                 </a>
-                                {% endif %}
+                                {%- endif -%}
+                                {%- if page.n_equal_contrib > 1 and forloop.index0 < page.n_equal_contrib -%}
+                                    <sup>&ast;</sup>
+                                {%- endif -%}
+                                </span>
                                 {% if author.orcid %}
                                     <a href="https://orcid.org/{{ author.orcid }}" target="_blank" rel="noopener noreferrer">
                                         <i class="ai ai-orcid"></i>


### PR DESCRIPTION
Remove link underscore from asterisks denoting equal contribution. The superscript element otherwise makes the underscore look like a hyphen.